### PR TITLE
fix: reg exp

### DIFF
--- a/src/main/ts/fix.ts
+++ b/src/main/ts/fix.ts
@@ -62,7 +62,7 @@ export const fixRelativeModuleReferences = (
   filenames: string[],
 ): string =>
   contents.replace(
-    /(\sfrom |\simport\()(["'])(\.\/[^"']+)(["'])/g,
+    /(\sfrom |\simport\()(["'])(\.{0,2}\/{0,1}[^"']+)(["'])/g,
     (matched, control, q1, from, q2) =>
       `${control}${q1}${resolveDependency(filename, from, filenames)}${q2}`,
   )

--- a/src/test/fixtures/ts-project/src/main/ts/index.ts
+++ b/src/test/fixtures/ts-project/src/main/ts/index.ts
@@ -4,6 +4,8 @@ export * from './foo'
 
 export * from './baz'
 
+export * from './q/u/x'
+
 export const foobaz = foo + 'baz'
 
 export const dirname = __dirname

--- a/src/test/fixtures/ts-project/src/main/ts/q/u/x/index.ts
+++ b/src/test/fixtures/ts-project/src/main/ts/q/u/x/index.ts
@@ -1,0 +1,3 @@
+import {foo} from '../../../foo'
+
+export const qux = foo

--- a/src/test/fixtures/ts-project/src/main/ts/q/u/x/index.ts
+++ b/src/test/fixtures/ts-project/src/main/ts/q/u/x/index.ts
@@ -1,3 +1,5 @@
 import {foo} from '../../../foo'
+import {baz} from '../../../baz'
 
 export const qux = foo
+export const quxbaz = baz;

--- a/src/test/fixtures/ts-project/target/es5/index.js
+++ b/src/test/fixtures/ts-project/target/es5/index.js
@@ -1,6 +1,7 @@
 import { foo } from './foo';
 export * from './foo';
 export * from './baz';
+export * from './q/u/x';
 export var foobaz = foo + 'baz';
 export var dirname = __dirname;
 export var filename = __filename;

--- a/src/test/fixtures/ts-project/target/es5/q/u/x/index.js
+++ b/src/test/fixtures/ts-project/target/es5/q/u/x/index.js
@@ -1,3 +1,5 @@
 import { foo } from '../../../foo';
+import { baz } from '../../../baz';
 export var qux = foo;
+export var quxbaz = baz;
 // # sourceMappingURL=index.js.map

--- a/src/test/fixtures/ts-project/target/es5/q/u/x/index.js
+++ b/src/test/fixtures/ts-project/target/es5/q/u/x/index.js
@@ -1,0 +1,3 @@
+import { foo } from '../../../foo';
+export var qux = foo;
+// # sourceMappingURL=index.js.map

--- a/src/test/fixtures/ts-project/target/es6/index.js
+++ b/src/test/fixtures/ts-project/target/es6/index.js
@@ -1,6 +1,7 @@
 import { foo } from './foo';
 export * from './foo';
 export * from './baz';
+export * from './q/u/x';
 export const foobaz = foo + 'baz';
 export const dirname = __dirname;
 export const filename = __filename;

--- a/src/test/fixtures/ts-project/target/es6/q/u/x/index.js
+++ b/src/test/fixtures/ts-project/target/es6/q/u/x/index.js
@@ -1,3 +1,5 @@
 import { foo } from '../../../foo';
+import { baz } from '../../../baz';
 export const qux = foo;
+export const quxbaz = baz;
 // # sourceMappingURL=index.js.map

--- a/src/test/fixtures/ts-project/target/es6/q/u/x/index.js
+++ b/src/test/fixtures/ts-project/target/es6/q/u/x/index.js
@@ -1,0 +1,3 @@
+import { foo } from '../../../foo';
+export const qux = foo;
+// # sourceMappingURL=index.js.map

--- a/src/test/ts/__snapshots__/fix.ts.snap
+++ b/src/test/ts/__snapshots__/fix.ts.snap
@@ -44,6 +44,14 @@ export const filename = __filename;
 // # sourceMappingURL=index.js.map"
 `;
 
+exports[`contents upper relative paths case 1`] = `
+"import { foo } from '../../../foo.js';
+import { baz } from '../../../baz/index.js';
+export const qux = foo;
+export const quxbaz = baz;
+// # sourceMappingURL=index.js.map"
+`;
+
 exports[`fix() patches some files as required by opts 1`] = `
 "import { foo } from './foo.mjs';
 export * from './foo.mjs';

--- a/src/test/ts/__snapshots__/fix.ts.snap
+++ b/src/test/ts/__snapshots__/fix.ts.snap
@@ -4,6 +4,7 @@ exports[`contents fixContents() assembles all content modifiers 1`] = `
 "import { foo } from './foo.js';
 export * from './foo.js';
 export * from './baz/index.js';
+export * from './q/u/x/index.js';
 export const foobaz = foo + 'baz';
 export const dirname = /file:\\\\/\\\\/(.+)\\\\/[^/]/.exec(import.meta.url)[1];
 export const filename = /file:\\\\/\\\\/(.+)/.exec(import.meta.url)[1];
@@ -14,6 +15,7 @@ exports[`contents fixDirnameVar() replaces __dirname refs 1`] = `
 "import { foo } from './foo';
 export * from './foo';
 export * from './baz';
+export * from './q/u/x';
 export const foobaz = foo + 'baz';
 export const dirname = /file:\\\\/\\\\/(.+)\\\\/[^/]/.exec(import.meta.url)[1];
 export const filename = __filename;
@@ -24,6 +26,7 @@ exports[`contents fixFilenameVar() replaces __filename refs 1`] = `
 "import { foo } from './foo';
 export * from './foo';
 export * from './baz';
+export * from './q/u/x';
 export const foobaz = foo + 'baz';
 export const dirname = __dirname;
 export const filename = /file:\\\\/\\\\/(.+)/.exec(import.meta.url)[1];
@@ -34,6 +37,7 @@ exports[`contents fixRelativeModuleReferences() appends file ext to module refs 
 "import { foo } from './foo.js';
 export * from './foo.js';
 export * from './baz/index.js';
+export * from './q/u/x/index.js';
 export const foobaz = foo + 'baz';
 export const dirname = __dirname;
 export const filename = __filename;
@@ -44,6 +48,7 @@ exports[`fix() patches some files as required by opts 1`] = `
 "import { foo } from './foo.mjs';
 export * from './foo.mjs';
 export * from './baz/index.mjs';
+export * from './q/u/x/index.mjs';
 export const foobaz = foo + 'baz';
 export const dirname = /file:\\\\/\\\\/(.+)\\\\/[^/]/.exec(import.meta.url)[1];
 export const filename = /file:\\\\/\\\\/(.+)/.exec(import.meta.url)[1];

--- a/src/test/ts/fix.ts
+++ b/src/test/ts/fix.ts
@@ -66,8 +66,15 @@ describe('contents', () => {
   const file = resolve(fakeProject, 'target/es6/index.js')
   const content = read(file)
 
+  const fileDeep = resolve(fakeProject, 'target/es6/q/u/x/index.js')
+  const contentDepp = read(fileDeep)
+
   it('fixRelativeModuleReferences() appends file ext to module refs', () => {
     expect(fixRelativeModuleReferences(content, file, files)).toMatchSnapshot()
+  })
+  
+  it('upper relative paths case', () => {
+    expect(fixRelativeModuleReferences(contentDepp, fileDeep, files)).toMatchSnapshot()
   })
 
   it('fixDirnameVar() replaces __dirname refs', () => {


### PR DESCRIPTION
fixed #5 


Modify a regular expression to work with these cases below
```
import tmp from '../tmp';
import tmp from '../../../tmp';
import tmp from 'tmp';
```

![image](https://user-images.githubusercontent.com/40482203/120920918-2a612580-c6fc-11eb-94c9-0be88d1d03cd.png)
